### PR TITLE
Authorization header bug fix

### DIFF
--- a/modules/swagger-codegen/src/main/resources/mercurius-go-server/lib/auth/verifier.mustache
+++ b/modules/swagger-codegen/src/main/resources/mercurius-go-server/lib/auth/verifier.mustache
@@ -48,8 +48,13 @@ func LoginRequired(ctx *context.Context) {
 func LoginRequiredApi(ctx *context.Context) {
     header := ctx.Req.Header.Get("Authorization")
     if header != "" {
-        value := strings.Split(header, " ")[1]
-        token, err := jwt.ParseWithClaims(value, &Claims{}, parse)
+        splitted := strings.Split(header, " ")
+		if len(splitted) < 2 {
+			ctx.JSON(http.StatusBadRequest, map[string]string{"error": "Malformed request header"})
+			return
+		}
+		value := splitted[1]
+		token, err := jwt.ParseWithClaims(value, &Claims{}, parse)
         if err != nil {
             ctx.JSON(http.StatusUnauthorized, map[string]string{"error": "Unauthorized"})
             return


### PR DESCRIPTION
I've written this workaround because I've noticed that Mercurius doesn't warn users about missing or malformed request headers and answer 200/OK for invalid requests, just print a huge error block on the server side that points to generated files and honestly, it doesn't help too much if you don't have access to servers logs.

I hope it helps. 😄 